### PR TITLE
Improve fetch file, don't get cached versions, log the name

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/shared-deps "0.2.6"
+(defproject clanhr/shared-deps "0.2.6.1"
   :description "Centralized declaration of dependencies for multi-projects"
   :url "https://github.com/clanhr/shared-deps"
   :license {:name "Apache Software License 2.0"

--- a/src/shared_deps/plugin.clj
+++ b/src/shared_deps/plugin.clj
@@ -123,7 +123,8 @@
 (defn- shared-dependencies
   [project]
   (if-let [source (get-source-file-name project)]
-    (read-dependencies-file source)
+    (do (spit ".dependencies.edn" (slurp source))
+        (read-dependencies-file source))
     (read-shared-dependencies project)))
 
 (defn- ->id-list

--- a/src/shared_deps/plugin.clj
+++ b/src/shared_deps/plugin.clj
@@ -109,10 +109,21 @@
                                     read-dependencies-file)]
     (merge sibling-dependencies shared-dependencies)))
 
+(def current-millis (System/currentTimeMillis))
+
+(defn- get-source-file-name
+  "Gets the source file name"
+  [project]
+  (when-let [path (:dependencies.edn project)]
+    (let [path (if (.startsWith path "http")
+                 (str path "?" current-millis)
+                 path)]
+      path)))
+
 (defn- shared-dependencies
   [project]
-  (if-let [source (:dependencies.edn project)]
-    (read-dependencies-file (:dependencies.edn project))
+  (if-let [source (get-source-file-name project)]
+    (read-dependencies-file source)
     (read-shared-dependencies project)))
 
 (defn- ->id-list


### PR DESCRIPTION
- Try to ignore cache
- Store used dependencies on `.dependencies.edn`

This last one will be useful if you don't have access to the internet (you can just point there) and will also serve as a snapshot of the dependencies at the time of the commit.
